### PR TITLE
Automatic plugin lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Those are the defaults options, which can be changed.
 {
     'vgitv/one-term.nvim',
     opts = {
-        bg_color = nil,  -- main terminal background color
+        bg_color_factor = 0.75,  -- factor to compute terminal bg color
         startinsert = false,  -- start insert mode at term opening
         relative_height = 0.35,  -- relative height of the terminal window (beetween 0 and 1)
         local_options = {
@@ -185,7 +185,7 @@ require('one-term').setup {}
 ```lua
 -- advanced usage
 require('one-term').setup {
-    bg_color = nil,  -- main terminal background color
+    bg_color_factor = 0.75,  -- factor to compute terminal bg color
     startinsert = false,  -- start insert mode at term opening
     relative_height = 0.35,  -- relative height of the terminal window (beetween 0 and 1)
     local_options = {

--- a/README.md
+++ b/README.md
@@ -137,18 +137,60 @@ up.
 **NB:** one-term will not define any key mapping for you, it only provides a
 user command. It's up to you to define you own mappings.
 
-### Minimal example with lazy.nvim
+### With Neovim native package management
+
+_Oneterm_ can be loaded using native package management (see `:help packages`).
+Just clone the repository into your `pack/*/start/` directory and restart
+Neovim. If you are satisfied with the defaults, nothing else is required, you
+can use the `Oneterm` command right away.
+
+Note that _Oneterm_ will lazy-load itself on the first `Oneterm` command, thus
+avoiding time-consuming startup.
+
+If you want to set specific options, you must explicitly call the setup
+function. Just pick the options you are interested in and put them into your
+nvim configuration. Here are the default options:
 
 ```lua
-{
-    'vgitv/one-term.nvim',
-    opts = {},
+require('one-term').setup {
+    bg_color_factor = 0.75,  -- factor to compute terminal bg color
+    startinsert = false,  -- start insert mode at term opening
+    relative_height = 0.35,  -- relative height of the terminal window (beetween 0 and 1)
+    local_options = {
+        number = false,  -- no number in main terminal window
+        relativenumber = false,  -- no relative number in main terminal window
+        cursorline = false,  -- cursor line in main terminal window
+        colorcolumn = '',  -- color column
+    },
+    errorformat = {
+        '([^ :]*):([0-9]):',  -- lua / cpp
+        '^ *File "(.*)", line ([0-9]+)',  -- python
+        '^(.*): line ([0-9]+)',  -- bash
+    },
 }
 ```
 
-### Longer example with lazy.nvim
+See `:help one-term-configuration` for details about configuration items.
 
-Those are the defaults options, which can be changed.
+### With lazy.nvim
+
+#### Minimal example
+
+If you are satisfied with the defaults, there is no need to call the setup
+function (that means you dont even have to define an empty _opt_ key). Note
+that _Oneterm_ will lazy-load itself on the first `Oneterm` command.
+
+```lua
+{
+    'vgitv/one-term.nvim'
+}
+```
+
+#### Longer example
+
+Those are the defaults options, which can be changed. Dont copy this
+configuration as is, just pick the options you want to override. Feel free to
+add lazy loading options and keymaps.
 
 ```lua
 {
@@ -171,39 +213,6 @@ Those are the defaults options, which can be changed.
     },
 }
 ```
-
-### Neovim native package management
-
-Make sure to add the plugin directory to your runtimepath, then call the setup
-function:
-
-```lua
--- simple usage
-require('one-term').setup {}
-```
-
-```lua
--- advanced usage
-require('one-term').setup {
-    bg_color_factor = 0.75,  -- factor to compute terminal bg color
-    startinsert = false,  -- start insert mode at term opening
-    relative_height = 0.35,  -- relative height of the terminal window (beetween 0 and 1)
-    local_options = {
-        number = false,  -- no number in main terminal window
-        relativenumber = false,  -- no relative number in main terminal window
-        cursorline = false,  -- cursor line in main terminal window
-        colorcolumn = '',  -- color column
-    },
-    errorformat = {
-        '([^ :]*):([0-9]):',  -- lua / cpp
-        '^ *File "(.*)", line ([0-9]+)',  -- python
-        '^(.*): line ([0-9]+)',  -- bash
-    },
-}
-```
-
-See `:help one-term-configuration` for details about configuration items.
-
 
 ## Details about the jump subcommand
 

--- a/README.md
+++ b/README.md
@@ -83,32 +83,31 @@ terminal buffer, you can still create it manually, the plugin will not mix them
 up.
 
 ```vim
-" create a split window and open a new terminal
+" Create a split window and open a new terminal
 :Oneterm toggle_window
 
-" close the window (the terminal will still run in the background)
+" Close the window (the terminal will still run in the background)
 :Oneterm toggle_window
 
-" open the terminal again, this time occupying 80% of the current window
+" Open the terminal again, this time occupying 80% of the current window
 :Oneterm toggle_window 0.8
 
-" close the terminal window again
+" Close the terminal window again
 :Oneterm toggle_window
 
-" terminal buffer is unlisted
+" Terminal buffer is unlisted
 :ls
 
-" you can see the terminal buffer this way
+" You can see the terminal buffer this way
 :ls!
 
-" open a terminal window occupying 30% of the current height
+" Open a terminal window occupying 30% of the current height
 :Oneterm toggle_window 0.3
 
-" 30% is not enough to see well... Let's increase the terminal height to
-" the maximum
+" 30% is not enough to see well... Let's increase the terminal height to the maximum
 :Oneterm toggle_fullheight
 
-" back to 30%
+" Back to 30%
 :Oneterm toggle_fullheight
 
 " When on an error message, jump to the corresponding problematic code

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Neovim Lua plugin to toggle a terminal window and more.
 * [Oneterm subcommands](#oneterm-subcommands)
 * [Learn by examples](#learn-by-examples)
 * [Installation](#installation)
+    + [With Neovim native package management](#with-neovim-native-package-management)
+    + [With lazy.nvim](#with-lazynvim)
 * [Details about the jump subcommand](#details-about-the-jump-subcommand)
 * [How to contribute](#how-to-contribute)
 * [Inspired from](#inspired-from)
@@ -213,6 +215,8 @@ add lazy loading options and keymaps.
     },
 }
 ```
+
+See `:help one-term-configuration` for details about configuration items.
 
 ## Details about the jump subcommand
 

--- a/doc/one-term.txt
+++ b/doc/one-term.txt
@@ -185,14 +185,14 @@ Here are some usage examples.
     " You can see the terminal buffer this way
     :ls!
 
-    " open a terminal window occupying 30% of the current height
+    " Open a terminal window occupying 30% of the current height
     :Oneterm toggle_window 0.3
 
     " 30% is not enough to see well... Let's increase the terminal height to
     " the maximum
     :Oneterm toggle_fullheight
 
-    " back to 30%
+    " Back to 30%
     :Oneterm toggle_fullheight
 
     " When on an error message, jump to the corresponding problematic code

--- a/doc/one-term.txt
+++ b/doc/one-term.txt
@@ -227,7 +227,7 @@ Default configuration:
 Advanced configuration:
 >lua
     require('one-term').setup {
-        bg_color = nil,  -- main terminal background color
+        bg_color_factor = 0.75,  -- factor to compute term bg color
         startinsert = false,  -- start insert mode at term opening
         relative_height = 0.35,  -- relative height of the terminal window
         local_options = {
@@ -247,12 +247,14 @@ Advanced configuration:
 
 Details about configuration items ~
 
-    bg_color: ~
+    bg_color_factor: ~
 
-        If `nil`, the background color will be guessed by applying a factor to
-        each red / green / blue part of the Normal background highlight group.
-        So be sure to load your colorscheme first. Else you could force the
-        backgroupe terminal color with a hex value, for instance `#151515`.
+        The background color is calculated by applying a factor to each red /
+        green / blue part of the Normal background highlight group, so the
+        terminal background is different, but consistent with the colorscheme.
+        Setting this option to 1 means that the terminal background will be
+        the same as the Normal background. Smaller values will give darker
+        backgrounds.
 
     startinsert: ~
 

--- a/doc/one-term.txt
+++ b/doc/one-term.txt
@@ -223,6 +223,9 @@ Default configuration:
 >lua
     require("one-term").setup {}
 <
+Note that if you are satisfied with the defaults, it is not even required to
+call the setup function. Just put the plugin into your runtimepath. The plugin
+will lazy-load itself on the first `Oneterm` command.
 
 Advanced configuration:
 >lua
@@ -254,7 +257,9 @@ Details about configuration items ~
         terminal background is different, but consistent with the colorscheme.
         Setting this option to 1 means that the terminal background will be
         the same as the Normal background. Smaller values will give darker
-        backgrounds.
+        backgrounds, higher values will give lighter backgrounds. Values
+        beetween 0.75 and 1.25 will usually give good results, feel free to
+        experiment.
 
     startinsert: ~
 

--- a/lua/builtin.lua
+++ b/lua/builtin.lua
@@ -1,5 +1,4 @@
--- Here are defined the :Terminal builtin subcommands:
--- :Terminal <builtin-subcommand>
+-- Here are defined the builtin subcommands
 
 local M = {}
 M.subcommands = {}

--- a/lua/builtin.lua
+++ b/lua/builtin.lua
@@ -5,9 +5,7 @@ local M = {}
 M.subcommands = {}
 
 local utils = require "utils"
-
--- plugin options
-local options = {}
+local config = require "config"
 
 -- terminal state
 local state = {
@@ -18,17 +16,13 @@ local state = {
     full_height = false, -- is terminal full height?
 }
 
-M.setup_options = function(opts)
-    options = opts or {}
-end
-
 ---Split current window
 ---@param relative_height number Relative height of the future window
 M.subcommands.toggle_window = function(relative_height)
-    relative_height = relative_height or options.relative_height
+    relative_height = relative_height or config.options.relative_height
     if not vim.api.nvim_win_is_valid(state.win) then
-        utils.create_or_open_terminal(state, relative_height, options.local_options, true)
-        if options.startinsert then
+        utils.create_or_open_terminal(state, relative_height, config.options.local_options, true)
+        if config.options.startinsert then
             vim.cmd.startinsert()
         end
     else
@@ -53,7 +47,7 @@ end
 
 -- Send line under cursor into the terminal
 M.subcommands.send_current_line = function()
-    utils.ensure_open_terminal(state, options.relative_height, options.local_options)
+    utils.ensure_open_terminal(state, config.options.relative_height, config.options.local_options)
     local current_line = vim.api.nvim_get_current_line()
     -- trim line
     local exec_line = current_line:gsub("^%s+", ""):gsub("%s+$", "")
@@ -67,7 +61,7 @@ end
 
 ---Send visually selected lines to the terminal
 M.subcommands.send_visual_lines = function()
-    utils.ensure_open_terminal(state, options.relative_height, options.local_options)
+    utils.ensure_open_terminal(state, config.options.relative_height, config.options.local_options)
     local start_line = vim.fn.getpos("'<")[2]
     local end_line = vim.fn.getpos("'>")[2]
     print(start_line, end_line)
@@ -88,7 +82,7 @@ M.subcommands.jump = function()
         local current_line = vim.api.nvim_get_current_line()
         local filepath = nil
         local linenumber = nil
-        for _, pattern in pairs(options.errorformat) do
+        for _, pattern in pairs(config.options.errorformat) do
             filepath, linenumber = string.match(current_line, pattern)
             if filepath and linenumber then
                 break
@@ -116,7 +110,7 @@ M.subcommands.run_previous = function()
         return
     end
 
-    utils.ensure_open_terminal(state, options.relative_height, options.local_options)
+    utils.ensure_open_terminal(state, config.options.relative_height, config.options.local_options)
 
     -- Send Ctrl-p signal to the terminal followed by carriage return
     vim.api.nvim_chan_send(state.chan, "\x10\x0d")
@@ -179,7 +173,7 @@ end
 ---@param ... any Command line
 M.subcommands.run = function(...)
     local cmd = table.concat({ ... }, " ")
-    utils.ensure_open_terminal(state, options.relative_height, options.local_options)
+    utils.ensure_open_terminal(state, config.options.relative_height, config.options.local_options)
     vim.api.nvim_chan_send(state.chan, cmd .. "\x0d")
     utils.scroll_down(state.win)
 end

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,0 +1,53 @@
+local M = {}
+
+---The main terminal background could be darker than the editor background
+---@param opts table
+local get_term_bg = function(opts)
+    local factor = opts.factor or 0.75
+    local color
+
+    if opts.bg_color then
+        color = opts.bg_color
+    else
+        -- Try to guess a good background color for the main terminal window.
+        local normal_bg = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal", create = false }).bg)
+
+        local red = tonumber("0x" .. string.sub(normal_bg, 2, 3))
+        local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
+        local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
+
+        local hex_red = string.format("%02x", red * factor)
+        local hex_green = string.format("%02x", green * factor)
+        local hex_blue = string.format("%02x", blue * factor)
+
+        color = "#" .. hex_red .. hex_green .. hex_blue
+
+        return color
+    end
+end
+
+M.options = {
+    bg_color = get_term_bg {},
+    startinsert = false,
+    relative_height = 0.35,
+    local_options = {
+        number = false,
+        relativenumber = false,
+        cursorline = false,
+        colorcolumn = "",
+        scrolloff = 0,
+    },
+    -- regex patterns used to jump to the error location
+    errorformat = {
+        "([^ :]*):([0-9]):", -- lua / cpp
+        '^ *File "(.*)", line ([0-9]+)', -- python
+        "^(.*): line ([0-9]+)", -- bash
+    },
+}
+
+---Override default options
+function M.setup(user_options)
+    M.options = vim.tbl_deep_extend("force", M.options, user_options or {})
+end
+
+return M

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,33 +1,29 @@
 local M = {}
 
+local init_called = false
+
 ---The main terminal background could be darker than the editor background
 ---@param opts table
 M.get_term_bg = function(opts)
-    local factor = opts.factor or 0.75
-    local color
+    local factor = math.max(0, opts.factor)
 
-    if opts.bg_color then
-        color = opts.bg_color
-    else
-        -- Try to guess a good background color for the main terminal window.
-        local normal_bg = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal", create = false }).bg)
+    -- Try to guess a good background color for the main terminal window.
+    local normal_bg = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal", create = false }).bg)
 
-        local red = tonumber("0x" .. string.sub(normal_bg, 2, 3))
-        local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
-        local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
+    -- TODO math.max if factor > 1
+    local red = tonumber("0x" .. string.sub(normal_bg, 2, 3))
+    local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
+    local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
 
-        local hex_red = string.format("%02x", red * factor)
-        local hex_green = string.format("%02x", green * factor)
-        local hex_blue = string.format("%02x", blue * factor)
+    local hex_red = string.format("%02x", red * factor)
+    local hex_green = string.format("%02x", green * factor)
+    local hex_blue = string.format("%02x", blue * factor)
 
-        color = "#" .. hex_red .. hex_green .. hex_blue
-
-        return color
-    end
+    return "#" .. hex_red .. hex_green .. hex_blue
 end
 
 M.options = {
-    bg_color = M.get_term_bg {},
+    bg_color_factor = 0.75,
     startinsert = false,
     relative_height = 0.35,
     local_options = {
@@ -45,9 +41,33 @@ M.options = {
     },
 }
 
+---Initialisation function
+local init = function()
+    local color = M.get_term_bg { factor = M.options.bg_color_factor }
+    vim.cmd.highlight("MainTerminalNormal guibg=" .. color)
+end
+
 ---Override default options
 function M.setup(user_options)
     M.options = vim.tbl_deep_extend("force", M.options, user_options or {})
+    init()
+    init_called = true
 end
+
+-- The init function must be run even if the setup function is not called
+if not init_called then
+    init()
+end
+
+-- when switching colorscheme, the bg color will adapt
+vim.api.nvim_create_autocmd("ColorScheme", {
+    desc = "Update terminal background color",
+    group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
+    callback = function()
+        print(M.options.bg_color_factor)
+        local bg_color = M.get_term_bg { factor = M.options.bg_color_factor }
+        vim.cmd.highlight("MainTerminalNormal guibg=" .. bg_color)
+    end,
+})
 
 return M

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -2,7 +2,7 @@ local M = {}
 
 ---The main terminal background could be darker than the editor background
 ---@param opts table
-local get_term_bg = function(opts)
+M.get_term_bg = function(opts)
     local factor = opts.factor or 0.75
     local color
 
@@ -27,7 +27,7 @@ local get_term_bg = function(opts)
 end
 
 M.options = {
-    bg_color = get_term_bg {},
+    bg_color = M.get_term_bg {},
     startinsert = false,
     relative_height = 0.35,
     local_options = {

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,27 +1,5 @@
 local M = {}
 
-local init_called = false
-
----The main terminal background could be darker than the editor background
----@param opts table
-M.get_term_bg = function(opts)
-    local factor = math.max(0, opts.factor)
-
-    -- Try to guess a good background color for the main terminal window.
-    local normal_bg = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal", create = false }).bg)
-
-    -- TODO math.max if factor > 1
-    local red = tonumber("0x" .. string.sub(normal_bg, 2, 3))
-    local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
-    local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
-
-    local hex_red = string.format("%02x", red * factor)
-    local hex_green = string.format("%02x", green * factor)
-    local hex_blue = string.format("%02x", blue * factor)
-
-    return "#" .. hex_red .. hex_green .. hex_blue
-end
-
 M.options = {
     bg_color_factor = 0.75,
     startinsert = false,
@@ -41,33 +19,9 @@ M.options = {
     },
 }
 
----Initialisation function
-local init = function()
-    local color = M.get_term_bg { factor = M.options.bg_color_factor }
-    vim.cmd.highlight("MainTerminalNormal guibg=" .. color)
-end
-
 ---Override default options
 function M.setup(user_options)
     M.options = vim.tbl_deep_extend("force", M.options, user_options or {})
-    init()
-    init_called = true
 end
-
--- The init function must be run even if the setup function is not called
-if not init_called then
-    init()
-end
-
--- when switching colorscheme, the bg color will adapt
-vim.api.nvim_create_autocmd("ColorScheme", {
-    desc = "Update terminal background color",
-    group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
-    callback = function()
-        print(M.options.bg_color_factor)
-        local bg_color = M.get_term_bg { factor = M.options.bg_color_factor }
-        vim.cmd.highlight("MainTerminalNormal guibg=" .. bg_color)
-    end,
-})
 
 return M

--- a/lua/init.lua
+++ b/lua/init.lua
@@ -1,21 +1,23 @@
+-- Plugin initialisation.
 -- This init module must be run even if the setup function is not called so the plugin is usable with default options
 -- without the need of calling the setup function with empty arguments.
 
 local config = require "config"
 
----The main terminal background could be darker than the editor background
----@param opts table
-local get_term_bg = function(opts)
-    local factor = math.max(0, opts.factor)
+---Compute main terminal background color
+---@param factor number Factor to apply to red / green / blue parts of Normal bg color
+---@return string: Terminal background color in the form #XXXXXX
+local get_term_bg = function(factor)
+    factor = math.max(0, factor or 0.75)
 
     -- Try to guess a good background color for the main terminal window.
     local normal_bg = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal", create = false }).bg)
 
-    -- TODO math.max("FF", factor) if factor > 1
     local red = tonumber("0x" .. string.sub(normal_bg, 2, 3))
     local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
     local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
 
+    -- if factor > 1, be sure not to exceed FF (=255)
     local hex_red = string.format("%02x", math.min(red * factor, 255))
     local hex_green = string.format("%02x", math.min(green * factor, 255))
     local hex_blue = string.format("%02x", math.min(blue * factor, 255))
@@ -23,9 +25,9 @@ local get_term_bg = function(opts)
     return "#" .. hex_red .. hex_green .. hex_blue
 end
 
----Initialisation function
+---Set terminal highlight group for later background color
 local set_term_hl = function()
-    local color = get_term_bg { factor = config.options.bg_color_factor }
+    local color = get_term_bg(config.options.bg_color_factor)
     vim.api.nvim_set_hl(0, "MainTerminalNormal", { bg = color })
 end
 

--- a/lua/init.lua
+++ b/lua/init.lua
@@ -16,9 +16,9 @@ local get_term_bg = function(opts)
     local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
     local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
 
-    local hex_red = string.format("%02x", red * factor)
-    local hex_green = string.format("%02x", green * factor)
-    local hex_blue = string.format("%02x", blue * factor)
+    local hex_red = string.format("%02x", math.min(red * factor, 255))
+    local hex_green = string.format("%02x", math.min(green * factor, 255))
+    local hex_blue = string.format("%02x", math.min(blue * factor, 255))
 
     return "#" .. hex_red .. hex_green .. hex_blue
 end
@@ -26,7 +26,7 @@ end
 ---Initialisation function
 local set_term_hl = function()
     local color = get_term_bg { factor = config.options.bg_color_factor }
-    vim.cmd.highlight("MainTerminalNormal guibg=" .. color)
+    vim.api.nvim_set_hl(0, "MainTerminalNormal", { bg = color })
 end
 
 -- when switching colorscheme, the bg color will adapt

--- a/lua/init.lua
+++ b/lua/init.lua
@@ -1,0 +1,41 @@
+-- This init module must be run even if the setup function is not called so the plugin is usable with default options
+-- without the need of calling the setup function with empty arguments.
+
+local config = require "config"
+
+---The main terminal background could be darker than the editor background
+---@param opts table
+local get_term_bg = function(opts)
+    local factor = math.max(0, opts.factor)
+
+    -- Try to guess a good background color for the main terminal window.
+    local normal_bg = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal", create = false }).bg)
+
+    -- TODO math.max("FF", factor) if factor > 1
+    local red = tonumber("0x" .. string.sub(normal_bg, 2, 3))
+    local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
+    local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
+
+    local hex_red = string.format("%02x", red * factor)
+    local hex_green = string.format("%02x", green * factor)
+    local hex_blue = string.format("%02x", blue * factor)
+
+    return "#" .. hex_red .. hex_green .. hex_blue
+end
+
+---Initialisation function
+local set_term_hl = function()
+    local color = get_term_bg { factor = config.options.bg_color_factor }
+    vim.cmd.highlight("MainTerminalNormal guibg=" .. color)
+end
+
+-- when switching colorscheme, the bg color will adapt
+vim.api.nvim_create_autocmd("ColorScheme", {
+    desc = "Update terminal background color",
+    group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
+    callback = function()
+        set_term_hl()
+    end,
+})
+
+set_term_hl()

--- a/lua/one-term.lua
+++ b/lua/one-term.lua
@@ -18,18 +18,4 @@ M.setup = function(opts)
     config.setup(opts)
 end
 
--- FIXME setting bg_color through setup function is no longer valid
-
-vim.cmd.highlight("MainTerminalNormal guibg=" .. config.options.bg_color)
-
--- when switching colorscheme, the bg color will adapt
-vim.api.nvim_create_autocmd("ColorScheme", {
-    desc = "Update terminal background color",
-    group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
-    callback = function()
-        local bg_color = config.get_term_bg {}
-        vim.cmd.highlight("MainTerminalNormal guibg=" .. bg_color)
-    end,
-})
-
 return M

--- a/lua/one-term.lua
+++ b/lua/one-term.lua
@@ -11,52 +11,12 @@ M.load_command = function(cmd, ...)
     builtin.subcommands[cmd](...)
 end
 
----The main terminal background could be darker than the editor background
----@param opts table
-local get_term_bg = function(opts)
-    local factor = math.max(0, opts.factor)
-
-    -- Try to guess a good background color for the main terminal window.
-    local normal_bg = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal", create = false }).bg)
-
-    -- TODO math.max("FF", factor) if factor > 1
-    local red = tonumber("0x" .. string.sub(normal_bg, 2, 3))
-    local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
-    local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
-
-    local hex_red = string.format("%02x", red * factor)
-    local hex_green = string.format("%02x", green * factor)
-    local hex_blue = string.format("%02x", blue * factor)
-
-    return "#" .. hex_red .. hex_green .. hex_blue
-end
-
----Initialisation function
-local set_term_hl = function()
-    local color = get_term_bg { factor = config.options.bg_color_factor }
-    vim.cmd.highlight("MainTerminalNormal guibg=" .. color)
-end
-
 ---Plugin setup function
 ---@param opts table Main setup options
 M.setup = function(opts)
     opts = opts or {}
     config.setup(opts)
-    set_term_hl()
+    require "init"
 end
-
--- This init function must be run even if the setup function is not called so the plugin is usable with default options
--- without the need of calling the setup function with empty arguments. It also means that this init function could be
--- executed twice (on the require and in the setup function).
-set_term_hl()
-
--- when switching colorscheme, the bg color will adapt
-vim.api.nvim_create_autocmd("ColorScheme", {
-    desc = "Update terminal background color",
-    group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
-    callback = function()
-        set_term_hl()
-    end,
-})
 
 return M

--- a/lua/one-term.lua
+++ b/lua/one-term.lua
@@ -2,107 +2,32 @@
 
 local M = {}
 local builtin = require "builtin"
+local config = require "config"
 
 ---Run a specific subcommand
 ---@param cmd string Subcommand name
 ---@param ... any Subcommand parameters
-local load_command = function(cmd, ...)
+M.load_command = function(cmd, ...)
     builtin.subcommands[cmd](...)
-end
-
----The main terminal background could be darker than the editor background
----@param opts table
-local set_term_bg_hi = function(opts)
-    local factor = opts.factor or 0.75
-    local color
-
-    if opts.bg_color then
-        color = opts.bg_color
-    else
-        -- Try to guess a good background color for the main terminal window.
-        local normal_bg = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal", create = false }).bg)
-
-        local red = tonumber("0x" .. string.sub(normal_bg, 2, 3))
-        local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
-        local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
-
-        local hex_red = string.format("%02x", red * factor)
-        local hex_green = string.format("%02x", green * factor)
-        local hex_blue = string.format("%02x", blue * factor)
-
-        color = "#" .. hex_red .. hex_green .. hex_blue
-    end
-
-    vim.cmd.highlight("MainTerminalNormal guibg=" .. color)
 end
 
 ---Plugin setup function
 ---@param opts table Main setup options
 M.setup = function(opts)
     opts = opts or {}
+    config.setup(opts)
+end
 
-    -- Plutin options
-    local options = {
-        bg_color = opts.bg_color or nil,
-        startinsert = opts.startinsert or false,
-        relative_height = opts.relative_height or 0.35,
-        local_options = {
-            number = opts.local_options.number or false,
-            relativenumber = opts.local_options.relativenumber or false,
-            cursorline = opts.local_options.cursorline or false,
-            colorcolumn = opts.local_options.colorcolumn or "",
-            scrolloff = opts.local_options.scrolloff or 0,
-        },
-        -- regex patterns used to jump to the error location
-        errorformat = opts.errorformat or {
-            "([^ :]*):([0-9]):", -- lua / cpp
-            '^ *File "(.*)", line ([0-9]+)', -- python
-            "^(.*): line ([0-9]+)", -- bash
-        },
-    }
+vim.cmd.highlight("MainTerminalNormal guibg=" .. config.options.bg_color)
 
-    -- make options visible from builtin module
-    builtin.setup_options(options)
-
-    -- define main terminal highlight group
-    set_term_bg_hi { bg_color = options.bg_color }
-
-    -- when switching colorscheme, the bg color will adapt
-    if not options.bg_color then
-        vim.api.nvim_create_autocmd("ColorScheme", {
-            desc = "Update terminal background color",
-            group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
-            callback = function()
-                set_term_bg_hi { bg_color = options.bg_color }
-            end,
-        })
-    end
-
-    -- Build subcommand completion list
-    local choices = {}
-    for subcommand, _ in pairs(builtin.subcommands) do
-        table.insert(choices, subcommand)
-    end
-    table.sort(choices)
-
-    -- User command
-    vim.api.nvim_create_user_command("Oneterm", function(o)
-        load_command(unpack(o.fargs))
-    end, {
-        desc = "Terminal main command (see :help one-term)",
-        range = true,
-        nargs = "*",
-        complete = function(arglead, line, _)
-            local l = vim.split(line, "%s+")
-            local matches = {}
-            if #l == 2 then
-                for _, cmd in ipairs(choices) do
-                    if string.match(cmd, "^" .. arglead) then
-                        table.insert(matches, cmd)
-                    end
-                end
-                return matches
-            end
+-- when switching colorscheme, the bg color will adapt
+if not config.options.bg_color then
+    vim.api.nvim_create_autocmd("ColorScheme", {
+        desc = "Update terminal background color",
+        group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
+        callback = function()
+            local bg_color = config.get_term_bg {}
+            vim.cmd.highlight("MainTerminalNormal guibg=" .. bg_color)
         end,
     })
 end

--- a/lua/one-term.lua
+++ b/lua/one-term.lua
@@ -11,11 +11,52 @@ M.load_command = function(cmd, ...)
     builtin.subcommands[cmd](...)
 end
 
+---The main terminal background could be darker than the editor background
+---@param opts table
+local get_term_bg = function(opts)
+    local factor = math.max(0, opts.factor)
+
+    -- Try to guess a good background color for the main terminal window.
+    local normal_bg = string.format("#%06x", vim.api.nvim_get_hl(0, { name = "Normal", create = false }).bg)
+
+    -- TODO math.max("FF", factor) if factor > 1
+    local red = tonumber("0x" .. string.sub(normal_bg, 2, 3))
+    local green = tonumber("0x" .. string.sub(normal_bg, 4, 5))
+    local blue = tonumber("0x" .. string.sub(normal_bg, 6, 7))
+
+    local hex_red = string.format("%02x", red * factor)
+    local hex_green = string.format("%02x", green * factor)
+    local hex_blue = string.format("%02x", blue * factor)
+
+    return "#" .. hex_red .. hex_green .. hex_blue
+end
+
+---Initialisation function
+local set_term_hl = function()
+    local color = get_term_bg { factor = config.options.bg_color_factor }
+    vim.cmd.highlight("MainTerminalNormal guibg=" .. color)
+end
+
 ---Plugin setup function
 ---@param opts table Main setup options
 M.setup = function(opts)
     opts = opts or {}
     config.setup(opts)
+    set_term_hl()
 end
+
+-- This init function must be run even if the setup function is not called so the plugin is usable with default options
+-- without the need of calling the setup function with empty arguments. It also means that this init function could be
+-- executed twice (on the require and in the setup function).
+set_term_hl()
+
+-- when switching colorscheme, the bg color will adapt
+vim.api.nvim_create_autocmd("ColorScheme", {
+    desc = "Update terminal background color",
+    group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
+    callback = function()
+        set_term_hl()
+    end,
+})
 
 return M

--- a/lua/one-term.lua
+++ b/lua/one-term.lua
@@ -18,18 +18,18 @@ M.setup = function(opts)
     config.setup(opts)
 end
 
+-- FIXME setting bg_color through setup function is no longer valid
+
 vim.cmd.highlight("MainTerminalNormal guibg=" .. config.options.bg_color)
 
 -- when switching colorscheme, the bg color will adapt
-if not config.options.bg_color then
-    vim.api.nvim_create_autocmd("ColorScheme", {
-        desc = "Update terminal background color",
-        group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
-        callback = function()
-            local bg_color = config.get_term_bg {}
-            vim.cmd.highlight("MainTerminalNormal guibg=" .. bg_color)
-        end,
-    })
-end
+vim.api.nvim_create_autocmd("ColorScheme", {
+    desc = "Update terminal background color",
+    group = vim.api.nvim_create_augroup("one_term_setup_augroup", { clear = true }),
+    callback = function()
+        local bg_color = config.get_term_bg {}
+        vim.cmd.highlight("MainTerminalNormal guibg=" .. bg_color)
+    end,
+})
 
 return M

--- a/plugin/one-term.lua
+++ b/plugin/one-term.lua
@@ -3,6 +3,7 @@ if vim.g.loaded_one_term == 1 then
 end
 
 vim.api.nvim_create_user_command("Oneterm", function(o)
+    require "init"
     require("one-term").load_command(unpack(o.fargs))
 end, {
     desc = "Terminal main command (see :help one-term)",

--- a/plugin/one-term.lua
+++ b/plugin/one-term.lua
@@ -1,0 +1,33 @@
+if vim.g.loaded_one_term == 1 then
+    return
+end
+
+vim.api.nvim_create_user_command("Oneterm", function(o)
+    require("one-term").load_command(unpack(o.fargs))
+end, {
+    desc = "Terminal main command (see :help one-term)",
+    range = true,
+    nargs = "*",
+    complete = function(arglead, line, _)
+        local l = vim.split(line, "%s+")
+        local matches = {}
+        local choices = {}
+
+        -- Build subcommand completion list
+        for subcommand, _ in pairs(require("builtin").subcommands) do
+            table.insert(choices, subcommand)
+        end
+        table.sort(choices)
+
+        if #l == 2 then
+            for _, cmd in ipairs(choices) do
+                if string.match(cmd, "^" .. arglead) then
+                    table.insert(matches, cmd)
+                end
+            end
+            return matches
+        end
+    end,
+})
+
+vim.g.loaded_one_term = 1

--- a/plugin/one-term.lua
+++ b/plugin/one-term.lua
@@ -11,16 +11,12 @@ end, {
     complete = function(arglead, line, _)
         local l = vim.split(line, "%s+")
         local matches = {}
-        local choices = {}
+        local subcommands = vim.tbl_keys(require("builtin").subcommands)
 
-        -- Build subcommand completion list
-        for subcommand, _ in pairs(require("builtin").subcommands) do
-            table.insert(choices, subcommand)
-        end
-        table.sort(choices)
+        table.sort(subcommands)
 
         if #l == 2 then
-            for _, cmd in ipairs(choices) do
+            for _, cmd in ipairs(subcommands) do
                 if string.match(cmd, "^" .. arglead) then
                     table.insert(matches, cmd)
                 end


### PR DESCRIPTION
### Description

There is no need to call the setup function with empty arguments anymore if satisfied with the defaults. If the setup function is not called, the plugin will lazy-load itself on the first `Oneterm` command.

The default options are now in a dedicated module _config_, so that it could be required in different modules.

Small fixes and improvements.